### PR TITLE
Update macos.md

### DIFF
--- a/_pages/macos.md
+++ b/_pages/macos.md
@@ -29,6 +29,8 @@ Install [Ansible][9]:
 
 `brew install ansible`
 
+Known issue: Currently the Pressbooks doesn't support ansible 2.8.4, please use previous versions. Note by Ling Ma
+
 Install [Virtualbox][10]:
 
 `brew cask install virtualbox`


### PR DESCRIPTION
ansible 2.8.4 will give:
ERROR! Unexpected Exception, this is probably a bug: 'PlaybookCLI' object has no attribute 'options'